### PR TITLE
Iron up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,9 @@
 name = "collabfict"
 version = "0.0.1"
 dependencies = [
+ "env_logger 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -15,6 +17,15 @@ dependencies = [
  "rustc-serialize 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -141,6 +152,11 @@ dependencies = [
 [[package]]
 name = "pnacl-build-helper"
 version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,191 @@
 [root]
 name = "collabfict"
 version = "0.0.1"
+dependencies = [
+ "iron 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cookie"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "openssl 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "error"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typeable 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gcc"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hyper"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cookie 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mucell 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsafe-any 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "iron"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "modifier 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plugin 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typemap 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libressl-pnacl-sys"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pnacl-build-helper 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "matches"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mime"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "modifier"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mucell"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "openssl"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "openssl-sys 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libressl-pnacl-sys 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phantom"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pkg-config"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "plugin"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phantom 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typemap 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pnacl-build-helper"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "time"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "typeable"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "typemap"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phantom 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsafe-any 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicase"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unsafe-any"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "url"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "collabfict"
 version = "0.0.1"
 dependencies = [
  "iron 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "router 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -141,6 +142,20 @@ dependencies = [
 name = "pnacl-build-helper"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "route-recognizer"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "router"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "iron 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "route-recognizer 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustc-serialize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ name = "collabfict"
 
 [dependencies.iron]
 version = "*"
+
+[dependencies.router]
+version = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ authors = [ "Ash Wilson <smashwilson@gmail.com>" ]
 [[bin]]
 
 name = "collabfict"
+
+[dependencies.iron]
+version = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ authors = [ "Ash Wilson <smashwilson@gmail.com>" ]
 
 name = "collabfict"
 
-[dependencies.iron]
-version = "*"
-
-[dependencies.router]
-version = "*"
+[dependencies]
+log = "0.2.1"
+env_logger = "0.2.1"
+iron = "0.1.5"
+router = "0.0.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,14 @@
+extern crate iron;
+
+use iron::prelude::*;
+use iron::status;
+
+fn health_check(_: &mut Request) -> IronResult<Response> {
+    Ok(Response::with((status::Ok, "Up and running.")))
+}
+
 fn main() {
-  println!("Up and running.");
+    Iron::new(health_check).listen("localhost:3000").unwrap();
+
+    println!("Collaborative fiction API server: alive and running.");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#[macro_use] extern crate log;
+extern crate env_logger;
 extern crate iron;
 extern crate router;
 
@@ -6,15 +8,18 @@ use iron::status;
 use router::Router;
 
 fn health_check(_: &mut Request) -> IronResult<Response> {
+    info!("Health check request.");
+
     Ok(Response::with((status::Ok, "Up and running.")))
 }
 
 fn main() {
+    env_logger::init().unwrap();
+
     let mut router = Router::new();
 
     router.get("/", health_check);
 
+    info!("Launching collaborative fiction API server on localhost:3000.");
     Iron::new(router).listen("localhost:3000").unwrap();
-
-    println!("Collaborative fiction API server: alive and running.");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,20 @@
 extern crate iron;
+extern crate router;
 
 use iron::prelude::*;
 use iron::status;
+use router::Router;
 
 fn health_check(_: &mut Request) -> IronResult<Response> {
     Ok(Response::with((status::Ok, "Up and running.")))
 }
 
 fn main() {
-    Iron::new(health_check).listen("localhost:3000").unwrap();
+    let mut router = Router::new();
+
+    router.get("/", health_check);
+
+    Iron::new(router).listen("localhost:3000").unwrap();
 
     println!("Collaborative fiction API server: alive and running.");
 }


### PR DESCRIPTION
Use the [Iron framework](http://ironframework.io/doc/iron/index.html) for serving and routing HTTP. Stick with the standard logger, for now.