### PR TITLE
Story locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "collabfict"
 version = "0.0.1"
 dependencies = [
  "bodyparser 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -15,7 +16,6 @@ dependencies = [
  "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -66,6 +66,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cfg-if"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "chrono"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "conduit-mime-types"
@@ -374,12 +383,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bufstream 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ url = "0.5.4"
 r2d2 = "0.6.3"
 r2d2_postgres = "0.10.0"
 plugin = "0.2.6"
-time = "0.1.34"
+chrono = "0.2.19"
 
 [dependencies.postgres]
 version = "0.11"
-features = ["time"]
+features = ["chrono"]

--- a/script/curlit
+++ b/script/curlit
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+[ -z "${TOKEN}" ] && {
+  echo "curlit: set your session token with 'export TOKEN=...'" >&2
+  exit 1
+}
+
+P=${1:-/}
+[ -n "$1" ] && shift
+
+METHOD=${1:-GET}
+[ -n "$1" ] && shift
+
+ARG=${ARG:-"-s"}
+
+curl \
+  ${ARG} \
+  -u "x:${TOKEN}" \
+  -X ${METHOD} \
+  -H 'Content-type: application/json' \
+  -H 'Accept: application/json' \
+  http://localhost:3000${P} "$@"
+
+echo

--- a/script/curlit
+++ b/script/curlit
@@ -5,11 +5,11 @@
   exit 1
 }
 
-P=${1:-/}
-[ -n "$1" ] && shift
-
 METHOD=${1:-GET}
-[ -n "$1" ] && shift
+shift
+
+P=${1:-"/"}
+shift
 
 ARG=${ARG:-"-s"}
 

--- a/script/psql
+++ b/script/psql
@@ -5,14 +5,11 @@
 set -euo pipefail
 
 SUDO="sudo "
-which boot2docker >/dev/null 2>&1 && SUDO=""
+which docker-machine >/dev/null 2>&1 && SUDO=""
 
 CONTAINER_ID=$(${SUDO} docker-compose ps -q db)
 
-exec ${SUDO} docker run \
-  --interactive=true \
-  --tty=true \
-  --rm=true \
+exec ${SUDO} docker run --rm -it \
   --link ${CONTAINER_ID}:postgres \
-  postgres \
+  postgres:9.5 \
   sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,7 @@ use iron;
 use rustc_serialize;
 use chrono::{DateTime, UTC};
 
-use error::FictError::{Message, Cause, NotFound, Unlocked, AlreadyLocked};
+use error::FictError::{Message, Cause, NotFound, Unlocked, Cooldown, AlreadyLocked};
 
 /// An Error type that can be used throughout the application. It can provide its own error message
 /// or wrap an underlying error of a different type.
@@ -24,6 +24,7 @@ pub enum FictError {
     Cause(Box<Error + Send>),
     NotFound,
     Unlocked,
+    Cooldown,
     AlreadyLocked { username: String, expiration: DateTime<UTC> }
 }
 
@@ -44,6 +45,7 @@ impl Error for FictError {
             Cause(ref e) => e.description(),
             NotFound => "Resource not found",
             Unlocked => "Resource not locked",
+            Cooldown => "Cooldown",
             AlreadyLocked {..} => "Unable to acquire a lock"
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,7 +52,7 @@ impl Error for FictError {
             Cause(ref e) => e.description(),
             NotFound => "Resource not found",
             Unlocked => "Resource not locked",
-            Cooldown => "Cooldown",
+            Cooldown => "Last contribution too recent",
             AlreadyLocked {..} => "Unable to acquire a lock"
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ mod auth;
 
 mod whoami;
 mod snippets;
+mod story;
 
 /// Respond with a simple string on `/` to be able to quickly check if it's up.
 fn health_check(_: &mut Request) -> IronResult<Response> {
@@ -65,6 +66,7 @@ fn launch() -> FictResult<()> {
     github.route(&mut router);
     whoami::route(&mut router);
     snippets::route(&mut router);
+    story::route(&mut router);
 
     let mut chain = Chain::new(router);
     try!(Database::link(&mut chain));

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ extern crate postgres;
 extern crate r2d2;
 extern crate r2d2_postgres;
 extern crate plugin;
-extern crate time;
+extern crate chrono;
 
 use std::env;
 use std::process;

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ mod auth;
 
 mod whoami;
 mod snippets;
-mod story;
+mod stories;
 
 /// Respond with a simple string on `/` to be able to quickly check if it's up.
 fn health_check(_: &mut Request) -> IronResult<Response> {
@@ -66,7 +66,7 @@ fn launch() -> FictResult<()> {
     github.route(&mut router);
     whoami::route(&mut router);
     snippets::route(&mut router);
-    story::route(&mut router);
+    stories::route(&mut router);
 
     let mut chain = Chain::new(router);
     try!(Database::link(&mut chain));

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -52,11 +52,11 @@ impl Database {
 
         // Reminder to self: this order is not arbitary. It must be organized such that foreign
         // keys are applied after the table they reference is created.
-        try!(User::initialize(&conn));
-        try!(Session::initialize(&conn));
-        try!(Story::initialize(&conn));
-        try!(StoryAccess::initialize(&conn));
-        try!(Snippet::initialize(&conn));
+        try!(User::initialize(&*conn));
+        try!(Session::initialize(&*conn));
+        try!(Story::initialize(&*conn));
+        try!(StoryAccess::initialize(&*conn));
+        try!(Snippet::initialize(&*conn));
 
         Ok(())
     }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -10,7 +10,8 @@ use postgres::rows::{Rows, Row};
 use r2d2::Pool;
 use r2d2_postgres::{PostgresConnectionManager, SslMode};
 
-use error::{FictResult, fict_err};
+use error::FictResult;
+use error::FictError::{NotFound};
 
 mod user;
 mod session;
@@ -72,7 +73,7 @@ fn first_opt<'a>(results: &'a Rows) -> FictResult<Option<Row<'a>>> {
 
     match it.next() {
         None => Ok(first),
-        Some(_) => Err(fict_err("Expected only one result, but more than one were returned")),
+        Some(_) => Err(NotFound),
     }
 }
 
@@ -80,5 +81,5 @@ fn first_opt<'a>(results: &'a Rows) -> FictResult<Option<Row<'a>>> {
 /// error if zero or more than one results are returned, or if the underlying query produces any.
 fn first<'a>(results: &'a Rows) -> FictResult<Row<'a>> {
     first_opt(results)
-        .and_then(|r| r.ok_or(fict_err("Expected at least one result, but zero were returned")))
+        .and_then(|r| r.ok_or(NotFound))
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -19,7 +19,7 @@ mod snippet;
 
 pub use self::user::User;
 pub use self::session::Session;
-pub use self::story::{Story, StoryAccess, AccessLevel};
+pub use self::story::{Story, StoryAccess, AccessLevel, ContributionAttempt};
 pub use self::snippet::Snippet;
 
 /// Database is the type key used to access the connection pool.
@@ -56,6 +56,7 @@ impl Database {
         try!(Session::initialize(&*conn));
         try!(Story::initialize(&*conn));
         try!(StoryAccess::initialize(&*conn));
+        try!(ContributionAttempt::initialize(&*conn));
         try!(Snippet::initialize(&*conn));
 
         Ok(())

--- a/src/model/snippet.rs
+++ b/src/model/snippet.rs
@@ -49,7 +49,7 @@ impl Snippet {
 
     /// Accept data to construct a `Snippet` that begins a new `Story` in draft status.
     pub fn begin(conn: &GenericConnection, owner: &User, content: String) -> FictResult<(Snippet, Story)> {
-        let story = try!(Story::begin(conn, owner, 1));
+        let story = try!(Story::begin(conn, owner));
 
         Snippet::contribute(conn, &story, owner, content)
             .map(|snippet| (snippet, story))

--- a/src/model/snippet.rs
+++ b/src/model/snippet.rs
@@ -77,4 +77,27 @@ impl Snippet {
         })
     }
 
+    /// Return the most recent Snippet associated with a given Story.
+    pub fn most_recent(conn: &GenericConnection, story: &Story) -> FictResult<Snippet> {
+        let selection = try!(conn.prepare("
+            SELECT id, ordinal, user_id, story_id, creation_time, content
+            FROM snippets
+            WHERE story_id = $1
+            ORDER BY ordinal DESC
+            LIMIT 1
+        "));
+
+        let rows = try!(selection.query(&[&story.id]));
+        let row = try!(first(&rows));
+
+        Ok(Snippet{
+            id: row.get(0),
+            ordinal: row.get(1),
+            user_id: row.get(2),
+            story_id: row.get(3),
+            creation_time: row.get(4),
+            content: row.get(5)
+        })
+    }
+
 }

--- a/src/model/snippet.rs
+++ b/src/model/snippet.rs
@@ -48,10 +48,11 @@ impl Snippet {
     }
 
     /// Accept data to construct a `Snippet` that begins a new `Story` in draft status.
-    pub fn begin(conn: &GenericConnection, owner: &User, content: String) -> FictResult<Snippet> {
-        let story = try!(Story::begin(conn, owner));
+    pub fn begin(conn: &GenericConnection, owner: &User, content: String) -> FictResult<(Snippet, Story)> {
+        let story = try!(Story::begin(conn, owner, 1));
 
         Snippet::contribute(conn, &story, owner, content)
+            .map(|snippet| (snippet, story))
     }
 
     /// Continue a `Story` in progress by creating a new `Snippet`.

--- a/src/model/story.rs
+++ b/src/model/story.rs
@@ -159,7 +159,7 @@ impl Story {
             exp >= now
         }).unwrap_or(false);
 
-        if locked_by_other && ! expiration_is_valid {
+        if locked_by_other && expiration_is_valid {
             let owner = try!(User::with_id(&transaction, story.lock_user_id.unwrap()));
 
             return Err(FictError::AlreadyLocked {

--- a/src/model/story.rs
+++ b/src/model/story.rs
@@ -55,16 +55,17 @@ impl Story {
 
     /// Create and persist a new `Story`. The provided `User` will be granted Owner-level access
     /// to the story.
-    pub fn begin(conn: &GenericConnection, owner: &User) -> FictResult<Story> {
+    pub fn begin(conn: &GenericConnection, owner: &User, contribution_count: i32) -> FictResult<Story> {
         let insertion = try!(conn.prepare("
-            INSERT INTO stories DEFAULT VALUES
+            INSERT INTO stories (contribution_count)
+            VALUES ($1)
             RETURNING
                 id, title, published, world_readable, lock_duration_s, contribution_count,
                 creation_time, update_time,
                 publish_time, lock_user_id, lock_expiration
         "));
 
-        let rows = try!(insertion.query(&[]));
+        let rows = try!(insertion.query(&[&contribution_count]));
         let row = try!(first(&rows));
 
         let story = Story{

--- a/src/model/story.rs
+++ b/src/model/story.rs
@@ -510,7 +510,7 @@ impl ContributionAttempt {
         let select = try!(conn.prepare("
             SELECT contribution_count
             FROM contribution_attempts
-            WHERE story_id = $1 AND user_id = $1
+            WHERE story_id = $1 AND user_id = $2
         "));
 
         let rows = try!(select.query(&[&story.id, &user.id]));

--- a/src/model/story.rs
+++ b/src/model/story.rs
@@ -123,6 +123,12 @@ impl Story {
         }
         let mut story = story_opt.unwrap();
 
+        // Applicant does not have sufficient permission to lock this story.
+        if ! story.access_for(conn, applicant).grants_write() {
+            return Err(FictError::NotFound);
+        }
+
+        // Applicant is not a persisted user. Caller error.
         let applicant_id = try!(applicant.id.ok_or(
             fict_err(format!("User {} must be persisted to lock a story.", applicant.name))
         ));
@@ -160,9 +166,9 @@ impl Story {
         story.lock_user_id = Some(applicant_id);
         story.lock_expiration = Some(lock_expiration);
 
-        // Return the locked story.
         try!(transaction.commit());
 
+        // Return the locked story.
         Ok(story)
     }
 

--- a/src/model/story.rs
+++ b/src/model/story.rs
@@ -359,12 +359,7 @@ impl AccessLevel {
 }
 
 /// Associates a level of access to a `Story` with a `User`.
-pub struct StoryAccess {
-    pub id: i64,
-    pub story_id: i64,
-    pub user_id: i64,
-    pub access_level: AccessLevel
-}
+pub struct StoryAccess;
 
 impl StoryAccess {
 

--- a/src/model/story.rs
+++ b/src/model/story.rs
@@ -520,7 +520,7 @@ impl ContributionAttempt {
     }
 
     /// Record a new contribution attempt.
-    fn record(conn: &GenericConnection, story: &Story, user: &User) -> FictResult<()> {
+    pub fn record(conn: &GenericConnection, story: &Story, user: &User) -> FictResult<()> {
         let update = try!(conn.prepare("
             UPDATE contribution_attempts
             SET contribution_count = $1

--- a/src/model/story.rs
+++ b/src/model/story.rs
@@ -55,17 +55,17 @@ impl Story {
 
     /// Create and persist a new `Story`. The provided `User` will be granted Owner-level access
     /// to the story.
-    pub fn begin(conn: &GenericConnection, owner: &User, contribution_count: i32) -> FictResult<Story> {
+    pub fn begin(conn: &GenericConnection, owner: &User) -> FictResult<Story> {
         let insertion = try!(conn.prepare("
-            INSERT INTO stories (contribution_count)
-            VALUES ($1)
+            INSERT INTO stories
+            DEFAULT VALUES
             RETURNING
                 id, title, published, world_readable, lock_duration_s, contribution_count,
                 creation_time, update_time,
                 publish_time, lock_user_id, lock_expiration
         "));
 
-        let rows = try!(insertion.query(&[&contribution_count]));
+        let rows = try!(insertion.query(&[]));
         let row = try!(first(&rows));
 
         let story = Story{

--- a/src/model/story.rs
+++ b/src/model/story.rs
@@ -88,7 +88,7 @@ impl Story {
     /// does not have sufficient access to write to this story, return `Err(FictError::NotFound)`.
     /// If the story is currently locked by someone else, return `Err(FictError::LockFailure)` with
     /// the lock details. Otherwise, return the locked `Story`.
-    pub fn locked_for_write(conn: &Connection, id: i16, applicant: &User) -> FictResult<Story> {
+    pub fn locked_for_write(conn: &Connection, id: i64, applicant: &User) -> FictResult<Story> {
         let now = UTC::now();
         let transaction = try!(conn.transaction());
 
@@ -124,7 +124,8 @@ impl Story {
         let mut story = story_opt.unwrap();
 
         // Applicant does not have sufficient permission to lock this story.
-        if ! story.access_for(conn, applicant).grants_write() {
+        let access = try!(story.access_for(conn, applicant));
+        if ! access.grants_write() {
             return Err(FictError::NotFound);
         }
 

--- a/src/snippets.rs
+++ b/src/snippets.rs
@@ -60,6 +60,9 @@ pub fn post(req: &mut Request) -> IronResult<Response> {
             try!(Snippet::contribute(&*conn, &story, &u, body.snippet.content)
                 .map_err(|err| err.iron(status::InternalServerError)));
 
+            try!(story.unlock(&*conn)
+                .map_err(|err| err.iron(status::InternalServerError)));
+
             Ok(Response::with(status::Created))
         },
         None => {

--- a/src/snippets.rs
+++ b/src/snippets.rs
@@ -8,7 +8,7 @@ use bodyparser;
 use plugin::Pluggable;
 use plugin::Extensible;
 
-use model::{Database, Snippet, Story};
+use model::{Database, Snippet, Story, ContributionAttempt};
 use auth::{AuthUser, RequireUser};
 use error::IntoIronResult;
 
@@ -67,7 +67,9 @@ pub fn post(req: &mut Request) -> IronResult<Response> {
             // created Snippet.
             debug!(".. Creating a new Story");
 
-            try!(Snippet::begin(conn, &u, body.snippet.content).iron());
+            let (_, story) = try!(Snippet::begin(conn, &u, body.snippet.content).iron());
+
+            try!(ContributionAttempt::record(conn, &story, &u).iron());
 
             Ok(Response::with(status::Created))
         }

--- a/src/snippets.rs
+++ b/src/snippets.rs
@@ -38,6 +38,8 @@ pub fn post(req: &mut Request) -> IronResult<Response> {
         }
     };
 
+    debug!("POST /snippets [{}]", u.name);
+
     let mutex = req.extensions().get::<Write<Database>>()
         .cloned()
         .expect("No database connection available");
@@ -46,6 +48,8 @@ pub fn post(req: &mut Request) -> IronResult<Response> {
 
     match body.snippet.story_id {
         Some(id) => {
+            debug!(".. Into existing story id {}", id);
+
             // Ensure that the current user holds an active lock on an existing Story.
             let mut story = try!(Story::locked_for_write(conn, id, &u, false).iron());
 
@@ -61,6 +65,7 @@ pub fn post(req: &mut Request) -> IronResult<Response> {
         None => {
             // Begin a new Story belonging to the authenticated User and containing the newly
             // created Snippet.
+            debug!(".. Creating a new Story");
 
             try!(Snippet::begin(conn, &u, body.snippet.content).iron());
 

--- a/src/snippets.rs
+++ b/src/snippets.rs
@@ -67,9 +67,12 @@ pub fn post(req: &mut Request) -> IronResult<Response> {
             // created Snippet.
             debug!(".. Creating a new Story");
 
-            let (_, story) = try!(Snippet::begin(conn, &u, body.snippet.content).iron());
+            let (_, mut story) = try!(Snippet::begin(conn, &u, body.snippet.content).iron());
 
             try!(ContributionAttempt::record(conn, &story, &u).iron());
+
+            story.contribution_count += 1;
+            try!(story.save(conn).iron());
 
             Ok(Response::with(status::Created))
         }

--- a/src/stories.rs
+++ b/src/stories.rs
@@ -12,7 +12,7 @@ use rustc_serialize::json;
 use model::{Database, Story, ContributionAttempt, Snippet};
 use auth::{AuthUser, RequireUser};
 use error::IntoIronResult;
-use error::FictError::{Cooldown, AlreadyLocked};
+use error::FictError::{Cooldown, AlreadyLocked, NotFound};
 
 #[derive(Debug, Clone, RustcEncodable)]
 struct LockGranted<'a> {
@@ -137,6 +137,11 @@ pub fn acquire_lock(req: &mut Request) -> IronResult<Response> {
                 .expect("Unable to encode response JSON");
 
             Ok(Response::with((status::Conflict, encoded)))
+        },
+        Err(NotFound) => {
+            debug!(".. Story not found or permission denied");
+
+            Ok(Response::with((status::NotFound, "Story not found")))
         },
         Err(e) => {
             error!("Unable to lock story for write: {:?}", e);

--- a/src/stories.rs
+++ b/src/stories.rs
@@ -129,7 +129,7 @@ pub fn acquire_lock(req: &mut Request) -> IronResult<Response> {
             let r = LockCooldownResponse {
                 lock: LockCooldown{
                     state: "denied",
-                    reason: "cooldown"
+                    reason: "last contribution too recent"
                 }
             };
 

--- a/src/stories.rs
+++ b/src/stories.rs
@@ -9,7 +9,7 @@ use persistent::Write;
 use plugin::Extensible;
 use rustc_serialize::json;
 
-use model::{Database, Story, ContributionAttempt};
+use model::{Database, Story, ContributionAttempt, Snippet};
 use auth::{AuthUser, RequireUser};
 use error::IntoIronResult;
 use error::FictError::{Cooldown, AlreadyLocked};
@@ -85,13 +85,15 @@ pub fn acquire_lock(req: &mut Request) -> IronResult<Response> {
                 format!("{}", exp.format(TIMESTAMP_FORMAT))
             }).expect("Story missing expiration date");
 
+            let snippet = try!(Snippet::most_recent(conn, &story).iron());
+
             let r = LockGrantedResponse {
                 lock: LockGranted{
                     state: "granted",
-                    expires: &formatted_expiration,
+                    expires: &formatted_expiration
                 },
                 snippet: PriorSnippet{
-                    content: "TODO"
+                    content: &snippet.content
                 }
             };
 

--- a/src/stories.rs
+++ b/src/stories.rs
@@ -1,6 +1,6 @@
 //! Story routes.
 //!
-//! * `POST /story/:id/lock` - Acquire a lock on the story :id.
+//! * `POST /stories/:id/lock` - Acquire a lock on the story :id.
 
 use iron::{Request, Response, IronResult, Chain};
 use iron::status;
@@ -57,7 +57,7 @@ struct LockCooldownResponse<'a> {
 /// Consistent DateTime format to be used throughout the API: `Fri, 10 May 2015 17:58:28 +0000`
 const TIMESTAMP_FORMAT: &'static str = "%a, %d %b %Y %T %z";
 
-/// `POST /story/:id/lock` to acquire a lock on an existing story and retrieve the most recent
+/// `POST /stories/:id/lock` to acquire a lock on an existing story and retrieve the most recent
 /// contributed Snippet.
 pub fn acquire_lock(req: &mut Request) -> IronResult<Response> {
     let applicant = req.extensions().get::<AuthUser>().cloned()
@@ -135,7 +135,7 @@ pub fn acquire_lock(req: &mut Request) -> IronResult<Response> {
     }
 }
 
-/// `DELETE /story/:id/lock` to revoke a lock on a story that you currently hold.
+/// `DELETE /stories/:id/lock` to revoke a lock on a story that you currently hold.
 pub fn revoke_lock(req: &mut Request) -> IronResult<Response> {
     let user = req.extensions().get::<AuthUser>().cloned()
         .expect("No authenticated user");
@@ -166,13 +166,13 @@ pub fn revoke_lock(req: &mut Request) -> IronResult<Response> {
     }
 }
 
-/// Register `/story` routes and their required middleware.
+/// Register `/stories` routes and their required middleware.
 pub fn route(router: &mut Router) {
     let mut acquire_lock_chain = Chain::new(acquire_lock);
     acquire_lock_chain.link_before(RequireUser);
-    router.post("/story/:id/lock", acquire_lock_chain);
+    router.post("/stories/:id/lock", acquire_lock_chain);
 
     let mut revoke_lock_chain = Chain::new(revoke_lock);
     revoke_lock_chain.link_before(RequireUser);
-    router.delete("/story/:id/lock", revoke_lock_chain);
+    router.delete("/stories/:id/lock", revoke_lock_chain);
 }

--- a/src/stories.rs
+++ b/src/stories.rs
@@ -107,7 +107,7 @@ pub fn acquire_lock(req: &mut Request) -> IronResult<Response> {
             Ok(Response::with((status::Ok, encoded)))
         },
         Err(AlreadyLocked { username, expiration }) => {
-            debug!(".. Lock denied: already held by {}.", username);
+            debug!(".. Lock denied: already held by [{}].", username);
 
             let r = LockConflictResponse {
                 lock: LockConflict{

--- a/src/story.rs
+++ b/src/story.rs
@@ -1,0 +1,105 @@
+//! Story routes.
+//!
+//! * `POST /story/:id/lock` - Acquire a lock on the story :id.
+
+use iron::{Request, Response, IronResult, IronError, Chain};
+use iron::status;
+use router::{Router, Params};
+use persistent::{Read, Write};
+use plugin::Extensible;
+use rustc_serialize::json;
+
+use model::{Database, Story};
+use auth::{AuthUser, RequireUser};
+use error::FictError::{AlreadyLocked, NotFound};
+
+#[derive(Debug, Clone, RustcEncodable)]
+struct LockGranted<'a> {
+    state: &'a str,
+    expires: &'a str
+}
+
+#[derive(Debug, Clone, RustcEncodable)]
+struct PriorSnippet<'a> {
+    content: &'a str
+}
+
+#[derive(Debug, Clone, RustcEncodable)]
+struct LockGrantedResponse<'a> {
+    lock: LockGranted<'a>,
+    snippet: PriorSnippet<'a>
+}
+
+#[derive(Debug, Clone, RustcEncodable)]
+struct LockDenied<'a> {
+    state: &'a str,
+    owner: &'a str,
+    expires: &'a str
+}
+
+#[derive(Debug, Clone, RustcEncodable)]
+struct LockDeniedResponse<'a> {
+    lock: LockDenied<'a>
+}
+
+pub fn acquire_lock(req: &mut Request) -> IronResult<Response> {
+    let applicant = req.extensions().get::<AuthUser>().cloned()
+        .expect("No authenticated user");
+
+    let params = req.extensions().get::<Router>()
+        .expect("No route parameters");
+    let story_id = match params["id"].parse::<i64>() {
+        Ok(i) => i,
+        Err(_) => return Ok(Response::with(("id must be numeric", status::BadRequest)))
+    };
+
+    let mutex = req.extensions().get::<Write<Database>>()
+        .cloned()
+        .expect("No database connection available");
+    let pool = mutex.lock().unwrap();
+    let conn = pool.get().unwrap();
+
+    match Story::locked_for_write(&*conn, story_id, &applicant) {
+        Ok(story) => {
+            let r = LockGrantedResponse {
+                lock: LockGranted{
+                    state: "granted",
+                    expires: "TODO",
+                },
+                snippet: PriorSnippet{
+                    content: "TODO"
+                }
+            };
+
+            let encoded = json::encode(&r)
+                .expect("Unable to encode response JSON");
+
+            Ok(Response::with((status::Ok, encoded)))
+        },
+        Err(AlreadyLocked { username, expiration }) => {
+            let r = LockDeniedResponse {
+                lock: LockDenied{
+                    state: "denied",
+                    owner: &username,
+                    expires: "TODO"
+                }
+            };
+
+            let encoded = json::encode(&r)
+                .expect("Unable to encode response JSON");
+
+            Ok(Response::with((status::Conflict, encoded)))
+        },
+        Err(e) => {
+            warn!("Unable to lock story for write: {:?}", e);
+            Err(e.iron(status::InternalServerError))
+        }
+    }
+}
+
+/// Register `/story` routes and their required middleware.
+pub fn route(router: &mut Router) {
+    let mut acquire_lock_chain = Chain::new(acquire_lock);
+    acquire_lock_chain.link_before(RequireUser);
+    router.post("/story/:id/lock", acquire_lock_chain);
+}

--- a/src/story.rs
+++ b/src/story.rs
@@ -2,7 +2,7 @@
 //!
 //! * `POST /story/:id/lock` - Acquire a lock on the story :id.
 
-use iron::{Request, Response, IronResult, IronError, Chain};
+use iron::{Request, Response, IronResult, Chain};
 use iron::status;
 use router::Router;
 use persistent::Write;
@@ -64,7 +64,7 @@ pub fn acquire_lock(req: &mut Request) -> IronResult<Response> {
     let pool = mutex.lock().unwrap();
     let conn = pool.get().unwrap();
 
-    match Story::locked_for_write(&*conn, story_id, &applicant) {
+    match Story::locked_for_write(&*conn, story_id, &applicant, true) {
         Ok(story) => {
             let formatted_expiration = story.lock_expiration.map(|exp| {
                 format!("{}", exp.format(TIMESTAMP_FORMAT))

--- a/src/whoami.rs
+++ b/src/whoami.rs
@@ -8,9 +8,9 @@ use rustc_serialize::json;
 use auth::{AuthUser, RequireUser};
 
 #[derive(RustcEncodable)]
-struct Payload {
-    name: String,
-    email: String
+struct Payload<'a> {
+    name: &'a str,
+    email: &'a str
 }
 
 /// Generate a JSON document containing information about the current user.
@@ -18,8 +18,8 @@ fn get(req: &mut Request) -> IronResult<Response> {
     let u = req.extensions.get::<AuthUser>().unwrap();
 
     let p = Payload{
-        name: u.name.clone(),
-        email: u.email.clone()
+        name: &u.name,
+        email: &u.email
     };
 
     let encoded = json::encode(&p).unwrap();

--- a/src/whoami.rs
+++ b/src/whoami.rs
@@ -17,6 +17,8 @@ struct Payload<'a> {
 fn get(req: &mut Request) -> IronResult<Response> {
     let u = req.extensions.get::<AuthUser>().unwrap();
 
+    debug!("GET /whoami [{}]", u.name);
+
     let p = Payload{
         name: &u.name,
         email: &u.email


### PR DESCRIPTION
Implementation of the story locking protocol described in #26.
- [x] Track recent contribution attempts. Deny locks against Stories that have been locked for contribution too recently by the lock applicant.
- [x] Query for the most recent Snippet associated with a locked Story in `acquire_lock`.
- [x] Record a contribution attempt when creating a new Story.
- [x] `curl` testing.

Optional:
- [x] Give `FictErrors` the ability to specify a preferred status code and refactor to clean up some of those handler match statements.
